### PR TITLE
Include files in gem spec

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
@@ -33,10 +33,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.4
+    - name: Set up Ruby 2.6
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.4
+        ruby-version: 2.6
 
     - name: Publish to RubyGems
       run: |

--- a/dce.gemspec
+++ b/dce.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.email       = 'xen@xen.dk'
   s.homepage    =
     'https://github.com/xendk/dce'
+  s.files = Dir['lib/*.rb'] + Dir['bin/*']
   s.executables << 'dce'
   s.license     = 'GPL-3.0'
 end


### PR DESCRIPTION
Currently installing via gems fails with "require_relative': cannot 
load such file -- 
/usr/local/lib/ruby/gems/2.7.0/gems/dce-1.1.0/lib/dce.rb”

According to the documentation files is a required attribute:
https://guides.rubygems.org/specification-reference/#files